### PR TITLE
chore: export missing components

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,14 @@ import { Button, Card, Section } from '@phcdevworks/spectrekit';
 
 ## 📚 Components
 
-| Component           | Description                                       |
-| ------------------- | ------------------------------------------------- |
-| `Button`            | Flexible button with variant + size options       |
-| `Card`              | Clean layout block with slot support              |
-| `Section`           | Wrapper with spacing + alignment control          |
-| `InfoBoxHorizontal` | CRO-enhanced horizontal feature display           |
-| `IconBox`           | Icon with label/description, perfect for features |
-| `Text`              | Responsive typographic primitives                 |
-| ...more             | New components added weekly                       |
+| Component    | Description                                       |
+| ------------ | ------------------------------------------------- |
+| `Button`     | Flexible button with variant + size options       |
+| `ButtonLink` | Anchor element styled as a button                 |
+| `Card`       | Clean layout block with slot support              |
+| `IconBox`    | Icon with label/description, perfect for features |
+| `Section`    | Wrapper with spacing + alignment control          |
+| ...more      | New components added weekly                       |
 
 > Full docs and preview site coming soon.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "exports": {
     ".": "./src/index.ts",
     "./components/Button.astro": "./components/Button.astro",
+    "./components/ButtonLink.astro": "./components/ButtonLink.astro",
     "./components/Card.astro": "./components/Card.astro",
+    "./components/IconBox.astro": "./components/IconBox.astro",
     "./components/Section.astro": "./components/Section.astro"
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export { default as Button } from '../components/Button.astro';
+export { default as ButtonLink } from '../components/ButtonLink.astro';
 export { default as Card } from '../components/Card.astro';
+export { default as IconBox } from '../components/IconBox.astro';
 export { default as Section } from '../components/Section.astro';


### PR DESCRIPTION
## Summary
- export ButtonLink and IconBox from index.ts and package exports
- sync README component list with available exports

## Testing
- `npx eslint .` *(fails: ESLint couldn't find an eslint.config.js)*
- `npx prettier --check README.md package.json src/index.ts`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689551c89d00832b99e6a38ec5b151da